### PR TITLE
[FG-4, FG-10] Refactor to AI-only analysis and add feed metadata extraction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,10 @@ gem "rails", "~> 8.0.2", ">= 8.0.2.1"
 gem "pg", "~> 1.1"
 # Use dotenv to load environment variables
 gem "dotenv-rails"
-# HTML parsing
-gem "nokogiri"
+# HTML parsing with JavaScript support
+gem "mechanize"
+# XML building
+gem "builder"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt_pbkdf (1.1.1)
@@ -89,6 +91,7 @@ GEM
     debug (1.11.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    domain_name (0.6.20240107)
     dotenv (3.1.8)
     dotenv-rails (3.1.8)
       dotenv (= 3.1.8)
@@ -104,6 +107,8 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    http-cookie (1.1.0)
+      domain_name (~> 0.5)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.1)
@@ -135,11 +140,31 @@ GEM
       net-pop
       net-smtp
     marcel (1.1.0)
+    mechanize (2.14.0)
+      addressable (~> 2.8)
+      base64
+      domain_name (~> 0.5, >= 0.5.20190701)
+      http-cookie (~> 1.0, >= 1.0.3)
+      mime-types (~> 3.3)
+      net-http-digest_auth (~> 1.4, >= 1.4.1)
+      net-http-persistent (>= 2.5.2, < 5.0.dev)
+      nkf
+      nokogiri (~> 1.11, >= 1.11.2)
+      rubyntlm (~> 0.6, >= 0.6.3)
+      webrick (~> 1.7)
+      webrobots (~> 0.1.2)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2025.0924)
     mini_mime (1.1.5)
     minitest (5.25.5)
     mocha (2.7.1)
       ruby2_keywords (>= 0.0.5)
     msgpack (1.8.0)
+    net-http-digest_auth (1.4.1)
+    net-http-persistent (4.0.6)
+      connection_pool (~> 2.2, >= 2.2.4)
     net-imap (0.5.10)
       date
       net-protocol
@@ -155,6 +180,7 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.4)
+    nkf (0.2.0)
     nokogiri (1.18.10-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.18.10-aarch64-linux-musl)
@@ -187,6 +213,7 @@ GEM
     psych (5.2.6)
       date
       stringio
+    public_suffix (6.0.2)
     puma (7.0.3)
       nio4r (~> 2.0)
     raabro (1.4.0)
@@ -266,6 +293,8 @@ GEM
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    rubyntlm (0.6.5)
+      base64
     securerandom (0.4.1)
     solid_cable (3.0.12)
       actioncable (>= 7.2)
@@ -304,6 +333,8 @@ GEM
     unicode-emoji (4.1.0)
     uri (1.0.3)
     useragent (0.16.11)
+    webrick (1.9.1)
+    webrobots (0.1.2)
     websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
@@ -324,11 +355,12 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   brakeman
+  builder
   debug
   dotenv-rails
   kamal
+  mechanize
   mocha
-  nokogiri
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 8.0.2, >= 8.0.2.1)

--- a/app/controllers/api/v1/feeds_controller.rb
+++ b/app/controllers/api/v1/feeds_controller.rb
@@ -16,4 +16,35 @@ class Api::V1::FeedsController < ApplicationController
       render json: { error: e.message }, status: :internal_server_error
     end
   end
+
+  def items
+    format = params[:format] || "json"
+    url = params[:url]
+    selector = params[:selector]
+
+    unless %w[rss json html].include?(format)
+      render json: { error: "Invalid format. Must be 'rss', 'json', or 'html'" }, status: :bad_request
+      return
+    end
+
+    if url.blank?
+      render json: { error: "url parameter is required" }, status: :bad_request
+      return
+    end
+
+    begin
+      result = FeedItemsService.new(url, selector).generate_items
+
+      case format
+      when "rss"
+        render xml: FeedFormatter.to_rss(url, result[:items], result[:feed_title], result[:feed_description]), content_type: "application/rss+xml"
+      when "html"
+        render html: FeedFormatter.to_html(url, result[:items], result[:feed_title], result[:feed_description]), content_type: "text/html"
+      else
+        render json: FeedFormatter.to_json(url, result[:items], result[:feed_title], result[:feed_description])
+      end
+    rescue StandardError => e
+      render json: { error: e.message }, status: :internal_server_error
+    end
+  end
 end

--- a/app/services/ai/base_provider.rb
+++ b/app/services/ai/base_provider.rb
@@ -4,6 +4,10 @@ module AI
       raise NotImplementedError, "Subclasses must implement analyze_containers"
     end
 
+    def extract_feed_items(html_structure, url)
+      raise NotImplementedError, "Subclasses must implement extract_feed_items"
+    end
+
     private
 
     def make_request(payload)

--- a/app/services/feed_analyzer.rb
+++ b/app/services/feed_analyzer.rb
@@ -1,5 +1,4 @@
-require "net/http"
-require "nokogiri"
+require "mechanize"
 
 class FeedAnalyzer
   TIMEOUT = 10
@@ -10,113 +9,44 @@ class FeedAnalyzer
   end
 
   def analyze
-    html = fetch_html
-    doc = Nokogiri::HTML(html)
+    page = fetch_page
+    doc = page.parser
 
-    # Use AI analysis if available, fallback to heuristic scoring
-    if use_ai_analysis?
-      ai_result = analyze_with_ai(doc)
-      element = find_element_by_selector(doc, ai_result["selector"])
+    ai_result = analyze_with_ai(doc)
+    element = find_element_by_selector(doc, ai_result["selector"])
 
-      if element
-        return {
-          url: @url,
-          primary_container: {
-            selector: ai_result["selector"],
-            confidence_score: ai_result["confidence_score"],
-            tag_name: element.name,
-            class_names: element["class"]&.split(" ") || [],
-            id: element["id"],
-            ai_reasoning: ai_result["reasoning"]
-          },
-          analyzed_at: Time.current.iso8601,
-          analysis_method: "ai"
-        }
-      end
-    end
-
-    # Fallback to heuristic analysis
-    containers = find_content_containers(doc)
-    scored_containers = score_containers(containers)
-    best_container = scored_containers.max_by { |c| c[:score] }
+    raise "Could not find element with selector: #{ai_result['selector']}" unless element
 
     {
       url: @url,
       primary_container: {
-        selector: generate_selector(best_container[:element]),
-        confidence_score: best_container[:score],
-        tag_name: best_container[:element].name,
-        class_names: best_container[:element]["class"]&.split(" ") || [],
-        id: best_container[:element]["id"]
+        selector: ai_result["selector"],
+        confidence_score: ai_result["confidence_score"],
+        tag_name: element.name,
+        class_names: element["class"]&.split(" ") || [],
+        id: element["id"],
+        ai_reasoning: ai_result["reasoning"]
       },
       analyzed_at: Time.current.iso8601,
-      analysis_method: "heuristic"
+      analysis_method: "ai"
     }
   end
 
   private
 
-  def fetch_html
-    uri = URI(@url)
+  def fetch_page
+    agent = Mechanize.new
+    agent.user_agent = "FeedGenerator/1.0"
+    agent.open_timeout = TIMEOUT
+    agent.read_timeout = TIMEOUT
 
-    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https",
-                    open_timeout: TIMEOUT, read_timeout: TIMEOUT) do |http|
-      request = Net::HTTP::Get.new(uri)
-      request["User-Agent"] = "FeedGenerator/1.0"
+    page = agent.get(@url)
 
-      response = http.request(request)
-
-      if response.body.bytesize > MAX_SIZE
-        raise "Content too large (#{response.body.bytesize} bytes)"
-      end
-
-      response.body
-    end
-  end
-
-  def find_content_containers(doc)
-    doc.css("div, article, section, main, aside").select do |element|
-      element.text.strip.length > 50
-    end
-  end
-
-  def score_containers(containers)
-    containers.map do |container|
-      {
-        element: container,
-        score: calculate_score(container)
-      }
-    end
-  end
-
-  def calculate_score(element)
-    score = 0
-
-    # Text content density
-    text_length = element.text.strip.length
-    html_length = element.to_html.length
-    text_ratio = text_length.to_f / html_length
-    score += text_ratio * 40
-
-    # Semantic tags bonus
-    score += 20 if %w[article main].include?(element.name)
-    score += 10 if %w[section].include?(element.name)
-
-    # Class/ID hints
-    content_indicators = %w[content main article post entry body text]
-    class_names = (element["class"] || "").downcase
-    id_name = (element["id"] || "").downcase
-
-    content_indicators.each do |indicator|
-      score += 15 if class_names.include?(indicator)
-      score += 20 if id_name.include?(indicator)
+    if page.body.bytesize > MAX_SIZE
+      raise "Content too large (#{page.body.bytesize} bytes)"
     end
 
-    # Position bonus (elements higher up get slight bonus)
-    position_score = [ 0, 100 - element.ancestors.length ].max
-    score += position_score * 0.1
-
-    score
+    page
   end
 
   def generate_selector(element)
@@ -129,20 +59,14 @@ class FeedAnalyzer
     end
   end
 
-  def use_ai_analysis?
-    ENV["USE_AI_ANALYSIS"] == "true" && ENV["OPENROUTER_API_KEY"].present?
-  end
-
   def analyze_with_ai(doc)
-    # Simplify HTML structure for AI analysis
     simplified_html = simplify_html_structure(doc)
     ai_provider = AI::Factory.create_provider
     ai_provider.analyze_containers(simplified_html)
   end
 
   def simplify_html_structure(doc)
-    # Extract key structural elements with their attributes
-    elements = doc.css('main, article, section, div[class*="content"], div[id*="content"]')
+    elements = doc.search('main, article, section, div[class*="content"], div[id*="content"]')
 
     elements.map do |el|
       {
@@ -156,7 +80,7 @@ class FeedAnalyzer
   end
 
   def find_element_by_selector(doc, selector)
-    doc.css(selector).first
+    doc.search(selector).first
   rescue
     nil
   end

--- a/app/services/feed_formatter.rb
+++ b/app/services/feed_formatter.rb
@@ -1,0 +1,78 @@
+class FeedFormatter
+  def self.to_json(url, items, feed_title = nil, feed_description = nil)
+    {
+      feed: {
+        title: feed_title || url,
+        description: feed_description || "Feed generated from #{url}",
+        url: url
+      },
+      items: items.map do |item|
+        {
+          title: item[:title],
+          link: item[:link],
+          published_at: item[:published_at]&.iso8601
+        }.compact
+      end
+    }
+  end
+
+  def self.to_rss(url, items, feed_title = nil, feed_description = nil)
+    require "builder"
+
+    xml = Builder::XmlMarkup.new(indent: 2)
+    xml.instruct! :xml, version: "1.0", encoding: "UTF-8"
+
+    xml.rss version: "2.0" do
+      xml.channel do
+        xml.title feed_title || url
+        xml.description feed_description || "Feed generated from #{url}"
+        xml.link url
+        xml.lastBuildDate Time.current.rfc2822
+
+        items.each do |item|
+          xml.item do
+            xml.title item[:title]
+            xml.link item[:link] if item[:link]
+            xml.pubDate item[:published_at].rfc2822 if item[:published_at]
+          end
+        end
+      end
+    end
+  end
+
+  def self.to_html(url, items, feed_title = nil, feed_description = nil)
+    title = feed_title || url
+    html = <<~HTML
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <title>#{title}</title>
+        <style>
+          body { font-family: Arial, sans-serif; margin: 40px; }
+          .item { margin-bottom: 30px; padding: 20px; border: 1px solid #ddd; }
+          .title { font-size: 18px; font-weight: bold; margin-bottom: 10px; }
+          .description { margin-bottom: 10px; }
+          .meta { color: #666; font-size: 14px; }
+        </style>
+      </head>
+      <body>
+        <h1>#{title}</h1>
+        #{feed_description ? "<p>#{feed_description}</p>" : ""}
+    HTML
+
+    items.each do |item|
+      html += <<~HTML
+        <div class="item">
+          <div class="title">#{item[:title]}</div>
+          <div class="meta">
+            #{item[:link] ? "<a href='#{item[:link]}'>Read more</a>" : ""}
+            #{item[:published_at] ? " | Published: #{item[:published_at].strftime('%B %d, %Y')}" : ""}
+          </div>
+        </div>
+      HTML
+    end
+
+    html += "</body></html>"
+    html
+  end
+end

--- a/app/services/feed_items_service.rb
+++ b/app/services/feed_items_service.rb
@@ -1,0 +1,90 @@
+require "mechanize"
+
+class FeedItemsService
+  def initialize(url, selector = nil)
+    @url = url
+    @selector = selector
+  end
+
+  def generate_items
+    page = fetch_page
+    return { feed_title: nil, feed_description: nil, items: [] } unless page
+
+    extract_with_ai(page)
+  end
+
+  private
+
+  def fetch_page
+    agent = Mechanize.new
+    agent.user_agent = "FeedGenerator/1.0"
+    agent.open_timeout = 10
+    agent.read_timeout = 10
+    agent.get(@url)
+  rescue StandardError => e
+    Rails.logger.error("[FeedItemsService] Failed to fetch #{@url}: #{e.message}")
+    nil
+  end
+
+  def extract_with_ai(page)
+    # Simplify HTML for AI processing
+    simplified_html = simplify_html_for_ai(page)
+
+    ai_provider = AI::Factory.create_provider
+    result = ai_provider.extract_feed_items(simplified_html, @url)
+
+    parse_ai_result(result)
+  rescue StandardError => e
+    Rails.logger.error("[FeedItemsService] AI extraction failed: #{e.message}")
+    { feed_title: nil, feed_description: nil, items: [] }
+  end
+
+  def simplify_html_for_ai(page)
+    # Extract relevant content containers
+    containers = page.search(@selector || "article, .post, .entry, .thing, li")
+
+    containers.first(20).map do |container|
+      {
+        html: container.to_html.truncate(1000),
+        text: container.text.strip.truncate(500)
+      }
+    end.to_json
+  end
+
+  def parse_ai_result(result)
+    return { feed_title: nil, feed_description: nil, items: [] } unless result.is_a?(Hash)
+
+    items = (result["items"] || []).map do |item|
+      {
+        title: item["title"],
+        link: absolute_url(item["link"]),
+        published_at: parse_published_at(item["published_at"])
+      }
+    end.compact
+
+    {
+      feed_title: result["feed_title"],
+      feed_description: result["feed_description"],
+      items: items
+    }
+  end
+
+  def parse_published_at(date_str)
+    return nil if date_str.blank?
+    Time.parse(date_str)
+  rescue ArgumentError
+    nil
+  end
+
+  def absolute_url(href)
+    return nil if href.blank?
+    return href if href.start_with?("http")
+
+    uri = URI(@url)
+    if href.start_with?("/")
+      "#{uri.scheme}://#{uri.host}#{href}"
+    else
+      "#{uri.scheme}://#{uri.host}/#{href}"
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post "feeds/analyze", to: "feeds#analyze"
+      get "feeds/items", to: "feeds#items"
     end
   end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    command: bash -c "rm -f tmp/pids/server.pid && bundle install && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - ".:/rails"
     ports:


### PR DESCRIPTION
- Remove heuristic analysis from FeedAnalyzer and FeedItemsService
- Enhance AI prompt to extract feed title and description
- Update FeedItemsService to return feed metadata along with items
- Update FeedFormatter to use extracted feed title and description
- Restore /analyze endpoint for container analysis needed by items service
- Add analyze_containers method back to AI providers